### PR TITLE
feat(ci): SRE-810 fallback to a patch release 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # **commit-analyzer**
 
+---
+Forked by Clearcover to add the following behaviour:
+  * If there are commits by the logs do not match any predefined style, fall back to performing a patch release.
+---
+
 [**semantic-release**](https://github.com/semantic-release/semantic-release) plugin to analyze commits with [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog)
 
 [![Travis](https://img.shields.io/travis/semantic-release/commit-analyzer.svg)](https://travis-ci.org/semantic-release/commit-analyzer)

--- a/index.js
+++ b/index.js
@@ -50,7 +50,8 @@ async function analyzeCommits(pluginConfig, context) {
     if (commitReleaseType) {
       logger.log('The release type for the commit is %s', commitReleaseType);
     } else {
-      logger.log('The commit should not trigger a release');
+      commitReleaseType = 'patch'
+      logger.log('The release type could not be determined from commit messages. Falling back to a patch release.');
     }
 
     // Set releaseType if commit's release type is higher

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@semantic-release/commit-analyzer",
+  "name": "@clearcover/commit-analyzer",
   "description": "semantic-release plugin to analyze commits with conventional-changelog",
   "version": "1.0.0",
   "author": "Pierre Vanduynslager (https://twitter.com/@pvdlg_)",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@semantic-release/commit-analyzer",
   "description": "semantic-release plugin to analyze commits with conventional-changelog",
-  "version": "0.0.0-development",
+  "version": "1.0.0",
   "author": "Pierre Vanduynslager (https://twitter.com/@pvdlg_)",
   "ava": {
     "files": [
@@ -47,7 +47,7 @@
     "lib",
     "index.js"
   ],
-  "homepage": "https://github.com/semantic-release/commit-analyzer#readme",
+  "homepage": "https://github.com/Clearcover/commit-analyzer#readme",
   "keywords": [
     "changelog",
     "commit-analyzer",
@@ -85,7 +85,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/semantic-release/commit-analyzer.git"
+    "url": "https://github.com/Clearcover/commit-analyzer.git"
   },
   "scripts": {
     "codecov": "codecov -f coverage/coverage-final.json",


### PR DESCRIPTION
If there are no commit messages which match the conventional commits format, fall back to a patch release.